### PR TITLE
Rename Sector Alarm to Phone Watch Alarm

### DIFF
--- a/custom_components/phonewatch/__init__.py
+++ b/custom_components/phonewatch/__init__.py
@@ -1,4 +1,4 @@
-"""Sector Alarm integration for Home Assistant."""
+"""Phone Watch Alarm integration for Home Assistant."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SectorAlarmConfigEntry) -> bool:
-    """Set up Sector Alarm from a config entry."""
+    """Set up Phone Watch Alarm from a config entry."""
     coordinator = SectorDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
@@ -35,7 +35,7 @@ async def async_update_listener(
 async def async_unload_entry(
     hass: HomeAssistant, entry: SectorAlarmConfigEntry
 ) -> bool:
-    """Unload a Sector Alarm config entry."""
+    """Unload a Phone Watch Alarm config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/custom_components/phonewatch/alarm_control_panel.py
+++ b/custom_components/phonewatch/alarm_control_panel.py
@@ -1,4 +1,4 @@
-"""Alarm Control Panel for Sector Alarm integration."""
+"""Alarm Control Panel for Phone Watch Alarm integration."""
 
 from __future__ import annotations
 
@@ -34,13 +34,13 @@ async def async_setup_entry(
     entry: SectorAlarmConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Sector Alarm control panel."""
+    """Set up the Phone Watch Alarm control panel."""
     coordinator = entry.runtime_data
-    async_add_entities([SectorAlarmControlPanel(coordinator)])
+    async_add_entities([PhoneWatchAlarmControlPanel(coordinator)])
 
 
-class SectorAlarmControlPanel(SectorAlarmBaseEntity, AlarmControlPanelEntity):
-    """Representation of the Sector Alarm control panel."""
+class PhoneWatchAlarmControlPanel(SectorAlarmBaseEntity, AlarmControlPanelEntity):
+    """Representation of the Phone Watch Alarm control panel."""
 
     _attr_name = None
     _attr_supported_features = (
@@ -55,13 +55,13 @@ class SectorAlarmControlPanel(SectorAlarmBaseEntity, AlarmControlPanelEntity):
         super().__init__(
             coordinator,
             coordinator.config_entry.data[CONF_PANEL_ID],
-            "Sector Alarm Panel",
+            "Phone Watch Alarm Panel",
             "Alarm panel",
         )
 
         self._attr_unique_id = f"{self._serial_no}_alarm_panel"
         _LOGGER.debug(
-            "Initialized Sector Alarm Control Panel with ID %s", self._attr_unique_id
+            "Initialized Phone Watch Alarm Control Panel with ID %s", self._attr_unique_id
         )
 
     @property

--- a/custom_components/phonewatch/client.py
+++ b/custom_components/phonewatch/client.py
@@ -5,19 +5,30 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import random
+import time
+from datetime import datetime, timedelta
+from typing import Any, Callable, TypeVar
 
 import aiohttp
 import async_timeout
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .const import CONFIG_TO_ENDPOINT_MAP
 from .endpoints import get_action_endpoints, get_data_endpoints
 
 _LOGGER = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
 
 class AuthenticationError(Exception):
     """Exception raised for authentication errors."""
+
+
+class TokenRefreshError(Exception):
+    """Exception raised for token refresh errors."""
 
 
 class SectorAlarmAPI:
@@ -25,17 +36,87 @@ class SectorAlarmAPI:
 
     API_URL = "https://mypagesapi.sectoralarm.net"
 
-    def __init__(self, hass: HomeAssistant, email, password, panel_id):
+    def __init__(self, hass: HomeAssistant, email, password, panel_id, enabled_endpoints=None):
         """Initialize the API client."""
         self.hass = hass
         self.email = email
         self.password = password
         self.panel_id = panel_id
         self.access_token = None
+        self.token_expiry = None
         self.headers: dict[str, str] = {}
         self.session = None
         self.data_endpoints = get_data_endpoints(self.panel_id)
         self.action_endpoints = get_action_endpoints()
+        self.enabled_endpoints = enabled_endpoints or {}
+        # Default retry configuration
+        self.max_retries = 3
+        self.base_delay = 1.0  # seconds
+        # Token management settings
+        self.token_lifetime = timedelta(hours=1)  # Conservative estimate, adjust as needed
+        self.token_refresh_margin = timedelta(minutes=5)  # Refresh 5 minutes before expiry
+
+    async def _retry_with_backoff(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        """Execute a function with exponential backoff retry logic."""
+        retries = 0
+        last_exception = None
+
+        while retries <= self.max_retries:
+            try:
+                return await func(*args, **kwargs)
+            except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+                last_exception = err
+                if retries == self.max_retries:
+                    break
+
+                # Calculate delay with exponential backoff and jitter
+                delay = min(2 ** retries * self.base_delay, 30)
+                jitter = random.uniform(0, 0.1 * delay)
+                total_delay = delay + jitter
+                
+                _LOGGER.warning(
+                    "Request failed, retrying in %.2f seconds (retry %d/%d): %s",
+                    total_delay,
+                    retries + 1,
+                    self.max_retries,
+                    str(err),
+                )
+                
+                await asyncio.sleep(total_delay)
+                retries += 1
+
+        # If we've exhausted all retries, raise the last exception
+        if isinstance(last_exception, asyncio.TimeoutError):
+            _LOGGER.error("Maximum retries reached, all attempts timed out")
+        else:
+            _LOGGER.error(
+                "Maximum retries reached, last error: %s", str(last_exception)
+            )
+        raise last_exception
+
+    def _is_token_valid(self) -> bool:
+        """Check if the current token is valid and not expired."""
+        if not self.access_token or not self.token_expiry:
+            return False
+        
+        # Add a margin to refresh the token before it actually expires
+        refresh_time = self.token_expiry - self.token_refresh_margin
+        return datetime.now() < refresh_time
+
+    async def ensure_authenticated(self):
+        """Ensure we have a valid access token, refreshing or authenticating as needed."""
+        if self.session is None:
+            self.session = async_get_clientsession(self.hass)
+            
+        if self._is_token_valid():
+            _LOGGER.debug("Using existing token, valid until %s", self.token_expiry)
+            return
+            
+        # We need a new token, perform full authentication
+        _LOGGER.debug("Token invalid or expired, authenticating...")
+        await self.login()
 
     async def login(self):
         """Authenticate with the API and obtain an access token."""
@@ -47,7 +128,8 @@ class SectorAlarmAPI:
             "userId": self.email,
             "password": self.password,
         }
-        try:
+        
+        async def _do_login():
             async with async_timeout.timeout(10):
                 async with self.session.post(login_url, json=payload) as response:
                     if response.status != 200:
@@ -60,11 +142,19 @@ class SectorAlarmAPI:
                     if not self.access_token:
                         _LOGGER.error("Login failed: No access token received")
                         raise AuthenticationError("Invalid credentials")
+                    
+                    # Set token expiry time
+                    self.token_expiry = datetime.now() + self.token_lifetime
+                    _LOGGER.debug("New token obtained, expires at %s", self.token_expiry)
+                    
                     self.headers = {
                         "Authorization": f"Bearer {self.access_token}",
                         "Accept": "application/json",
                     }
-
+        
+        try:
+            # Authentication errors shouldn't be retried, so we don't use retry logic here
+            await _do_login()
         except asyncio.TimeoutError as err:
             _LOGGER.error("Timeout occurred during login")
             raise AuthenticationError("Timeout during login") from err
@@ -76,17 +166,22 @@ class SectorAlarmAPI:
         """Retrieve available panels from the API."""
         data = {}
         panellist_url = f"{self.API_URL}/api/account/GetPanelList"
-        response = await self._get(panellist_url)
-        _LOGGER.debug(f"panel_payload: {response}")
+        
+        try:
+            await self.ensure_authenticated()
+            response = await self._retry_with_backoff(self._get, panellist_url)
+            _LOGGER.debug(f"panel_payload: {response}")
 
-        if response:
-            data = {
-                item["PanelId"]: item["DisplayName"]
-                for item in response
-                if "PanelId" in item
-            }
-        else:
-            _LOGGER.error("Failed to retrieve any panels")
+            if response:
+                data = {
+                    item["PanelId"]: item["DisplayName"]
+                    for item in response
+                    if "PanelId" in item
+                }
+            else:
+                _LOGGER.error("Failed to retrieve any panels")
+        except Exception as err:
+            _LOGGER.error("Error retrieving panel list: %s", str(err))
 
         return data
 
@@ -94,36 +189,92 @@ class SectorAlarmAPI:
         """Retrieve all relevant data from the API."""
         data = {}
 
-        # Iterate over data endpoints
-        for key, (method, url) in self.data_endpoints.items():
-            if method == "GET":
-                response = await self._get(url)
-            elif method == "POST":
-                # For POST requests, we need to provide the panel ID in the payload
-                payload = {"PanelId": self.panel_id}
-                response = await self._post(url, payload)
-            else:
-                _LOGGER.error("Unsupported HTTP method %s for endpoint %s", method, key)
-                continue
+        try:
+            # Ensure we have a valid authentication token before making requests
+            await self.ensure_authenticated()
+            
+            # Iterate over data endpoints
+            for config_option, endpoint_key in CONFIG_TO_ENDPOINT_MAP.items():
+                # Skip disabled endpoints
+                if config_option in self.enabled_endpoints and not self.enabled_endpoints[config_option]:
+                    _LOGGER.debug("Skipping disabled endpoint: %s", endpoint_key)
+                    continue
+                    
+                if endpoint_key not in self.data_endpoints:
+                    _LOGGER.debug("Endpoint not found in data_endpoints: %s", endpoint_key)
+                    continue
+                    
+                method, url = self.data_endpoints[endpoint_key]
+                    
+                try:
+                    if method == "GET":
+                        response = await self._retry_with_backoff(self._get, url)
+                    elif method == "POST":
+                        # For POST requests, we need to provide the panel ID in the payload
+                        payload = {"PanelId": self.panel_id}
+                        response = await self._retry_with_backoff(self._post, url, payload)
+                    else:
+                        _LOGGER.error("Unsupported HTTP method %s for endpoint %s", method, endpoint_key)
+                        continue
 
-            if response:
-                data[key] = response
-            else:
-                _LOGGER.info("No data retrieved for %s", key)
+                    if response:
+                        data[endpoint_key] = response
+                    else:
+                        _LOGGER.info("No data retrieved for %s", endpoint_key)
+                except Exception as err:
+                    _LOGGER.error("Error retrieving data for %s: %s", endpoint_key, str(err))
 
-        locks_status = await self.get_lock_status()
-        data["Lock Status"] = locks_status
+            # Always fetch panel status regardless of settings
+            try:
+                panel_status_method, panel_status_url = self.data_endpoints["Panel Status"]
+                panel_response = await self._retry_with_backoff(self._get, panel_status_url)
+                if panel_response:
+                    data["Panel Status"] = panel_response
+            except Exception as err:
+                _LOGGER.error("Error retrieving panel status: %s", str(err))
+                
+            # Always fetch locks status if not otherwise configured
+            lock_key = "Lock Status"
+            fetch_locks = True
+            if "lock_status" in self.enabled_endpoints:
+                fetch_locks = self.enabled_endpoints["lock_status"]
+                
+            if fetch_locks:
+                try:
+                    locks_status = await self.get_lock_status()
+                    data[lock_key] = locks_status
+                except Exception as err:
+                    _LOGGER.error("Error retrieving lock status: %s", str(err))
+                    data[lock_key] = []
 
+            # Always fetch logs for event handling
+            try:
+                logs_method, logs_url = self.data_endpoints["Logs"]
+                logs_response = await self._retry_with_backoff(self._get, logs_url)
+                if logs_response:
+                    data["Logs"] = logs_response
+            except Exception as err:
+                _LOGGER.error("Error retrieving logs: %s", str(err))
+                
+        except AuthenticationError as err:
+            _LOGGER.error("Authentication error during data retrieval: %s", str(err))
+            raise
+            
         return data
 
     async def get_lock_status(self):
         """Retrieve the lock status."""
         url = f"{self.API_URL}/api/panel/GetLockStatus?panelId={self.panel_id}"
-        response = await self._get(url)
-        if response:
-            return response
-        else:
-            _LOGGER.error("Failed to retrieve lock status")
+        try:
+            await self.ensure_authenticated()
+            response = await self._retry_with_backoff(self._get, url)
+            if response:
+                return response
+            else:
+                _LOGGER.error("Failed to retrieve lock status")
+                return []
+        except Exception as err:
+            _LOGGER.error("Error retrieving lock status: %s", str(err))
             return []
 
     async def _get(self, url):
@@ -141,6 +292,12 @@ class SectorAlarmAPI:
                                 "Received non-JSON response from %s: %s", url, text
                             )
                             return None
+                    elif response.status == 401:
+                        _LOGGER.warning("Authorization token expired, will re-authenticate")
+                        # Clear token data so we re-authenticate on next call
+                        self.access_token = None
+                        self.token_expiry = None
+                        raise AuthenticationError("Token expired")
                     else:
                         text = await response.text()
                         _LOGGER.error(
@@ -152,10 +309,10 @@ class SectorAlarmAPI:
                         return None
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout occurred during GET request to %s", url)
-            return None
+            raise
         except aiohttp.ClientError as e:
             _LOGGER.error("Client error during GET request to %s: %s", url, str(e))
-            return None
+            raise
 
     async def _post(self, url, payload):
         """Helper method to perform POST requests with timeout."""
@@ -174,6 +331,12 @@ class SectorAlarmAPI:
                                 "Received non-JSON response from %s: %s", url, text
                             )
                             return None
+                    elif response.status == 401:
+                        _LOGGER.warning("Authorization token expired, will re-authenticate")
+                        # Clear token data so we re-authenticate on next call
+                        self.access_token = None
+                        self.token_expiry = None
+                        raise AuthenticationError("Token expired")
                     else:
                         text = await response.text()
                         _LOGGER.error(
@@ -185,10 +348,10 @@ class SectorAlarmAPI:
                         return None
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout occurred during POST request to %s", url)
-            return None
+            raise
         except aiohttp.ClientError as err:
             _LOGGER.error("Client error during POST request to %s: %s", url, str(err))
-            return None
+            raise
 
     async def arm_system(self, mode: str, code: str):
         """Arm the alarm system."""
@@ -202,12 +365,18 @@ class SectorAlarmAPI:
             "PanelCode": panel_code,
             "PanelId": self.panel_id,
         }
-        result = await self._post(url, payload)
-        if result is not None:
-            _LOGGER.debug("System armed successfully")
-            return True
-        else:
-            _LOGGER.error("Failed to arm system")
+        
+        try:
+            await self.ensure_authenticated()
+            result = await self._retry_with_backoff(self._post, url, payload)
+            if result is not None:
+                _LOGGER.debug("System armed successfully")
+                return True
+            else:
+                _LOGGER.error("Failed to arm system")
+                return False
+        except Exception as err:
+            _LOGGER.error("Error while arming system: %s", str(err))
             return False
 
     async def disarm_system(self, code: str):
@@ -218,12 +387,18 @@ class SectorAlarmAPI:
             "PanelCode": panel_code,
             "PanelId": self.panel_id,
         }
-        result = await self._post(url, payload)
-        if result is not None:
-            _LOGGER.debug("System disarmed successfully")
-            return True
-        else:
-            _LOGGER.error("Failed to disarm system")
+        
+        try:
+            await self.ensure_authenticated()
+            result = await self._retry_with_backoff(self._post, url, payload)
+            if result is not None:
+                _LOGGER.debug("System disarmed successfully")
+                return True
+            else:
+                _LOGGER.error("Failed to disarm system")
+                return False
+        except Exception as err:
+            _LOGGER.error("Error while disarming system: %s", str(err))
             return False
 
     async def lock_door(self, serial_no: str, code: str):
@@ -236,12 +411,18 @@ class SectorAlarmAPI:
             "PanelId": self.panel_id,
             "SerialNo": serial_no,
         }
-        result = await self._post(url, payload)
-        if result is not None:
-            _LOGGER.debug("Door %s locked successfully", serial_no)
-            return True
-        else:
-            _LOGGER.error("Failed to lock door %s", serial_no)
+        
+        try:
+            await self.ensure_authenticated()
+            result = await self._retry_with_backoff(self._post, url, payload)
+            if result is not None:
+                _LOGGER.debug("Door %s locked successfully", serial_no)
+                return True
+            else:
+                _LOGGER.error("Failed to lock door %s", serial_no)
+                return False
+        except Exception as err:
+            _LOGGER.error("Error while locking door %s: %s", serial_no, str(err))
             return False
 
     async def unlock_door(self, serial_no: str, code: str):
@@ -254,59 +435,105 @@ class SectorAlarmAPI:
             "PanelId": self.panel_id,
             "SerialNo": serial_no,
         }
-        result = await self._post(url, payload)
-        if result is not None:
-            _LOGGER.debug("Door %s unlocked successfully", serial_no)
-            return True
-        else:
-            _LOGGER.error("Failed to unlock door %s", serial_no)
+        
+        try:
+            await self.ensure_authenticated()
+            result = await self._retry_with_backoff(self._post, url, payload)
+            if result is not None:
+                _LOGGER.debug("Door %s unlocked successfully", serial_no)
+                return True
+            else:
+                _LOGGER.error("Failed to unlock door %s", serial_no)
+                return False
+        except Exception as err:
+            _LOGGER.error("Error while unlocking door %s: %s", serial_no, str(err))
             return False
 
     async def turn_on_smartplug(self, plug_id):
-        """Turn on a smart plug."""
+        """Turn on a specific smart plug."""
         url = self.action_endpoints["TurnOnSmartplug"][1]
         payload = {
             "PanelId": self.panel_id,
-            "DeviceId": plug_id,
+            "SmartplugId": plug_id,
         }
-        result = await self._post(url, payload)
-        if result is not None:
-            _LOGGER.debug("Smart plug %s turned on successfully", plug_id)
-            return True
-        else:
-            _LOGGER.error("Failed to turn on smart plug %s", plug_id)
+        
+        try:
+            await self.ensure_authenticated()
+            result = await self._retry_with_backoff(self._post, url, payload)
+            if result is not None:
+                _LOGGER.debug("Smart plug %s turned on successfully", plug_id)
+                return True
+            else:
+                _LOGGER.error("Failed to turn on smart plug %s", plug_id)
+                return False
+        except Exception as err:
+            _LOGGER.error("Error while turning on smart plug %s: %s", plug_id, str(err))
             return False
 
     async def turn_off_smartplug(self, plug_id):
-        """Turn off a smart plug."""
+        """Turn off a specific smart plug."""
         url = self.action_endpoints["TurnOffSmartplug"][1]
         payload = {
             "PanelId": self.panel_id,
-            "DeviceId": plug_id,
+            "SmartplugId": plug_id,
         }
-        result = await self._post(url, payload)
-        if result is not None:
-            _LOGGER.debug("Smart plug %s turned off successfully", plug_id)
-            return True
-        else:
-            _LOGGER.error("Failed to turn off smart plug %s", plug_id)
+        
+        try:
+            await self.ensure_authenticated()
+            result = await self._retry_with_backoff(self._post, url, payload)
+            if result is not None:
+                _LOGGER.debug("Smart plug %s turned off successfully", plug_id)
+                return True
+            else:
+                _LOGGER.error("Failed to turn off smart plug %s", plug_id)
+                return False
+        except Exception as err:
+            _LOGGER.error("Error while turning off smart plug %s: %s", plug_id, str(err))
             return False
 
     async def get_camera_image(self, serial_no):
-        """Retrieve the latest image from a camera."""
-        url = f"{self.API_URL}/api/camera/GetCameraImage"
+        """Get a camera image."""
+        url = f"{self.API_URL}/api/panel/GetCameraImage"
         payload = {
             "PanelId": self.panel_id,
-            "SerialNo": serial_no,
+            "CameraId": serial_no,
         }
-        response = await self._post(url, payload)
-        if response and response.get("ImageData"):
-            image_data = base64.b64decode(response["ImageData"])
-            return image_data
-        _LOGGER.error("Failed to retrieve image for camera %s", serial_no)
-        return None
+        
+        try:
+            await self.ensure_authenticated()
+            async with async_timeout.timeout(20):  # Longer timeout for image retrieval
+                async with self.session.post(
+                    url, json=payload, headers=self.headers
+                ) as response:
+                    if response.status == 200:
+                        content_type = response.headers.get("Content-Type", "")
+                        if "image/" in content_type or "application/octet-stream" in content_type:
+                            return await response.read()
+                        else:
+                            _LOGGER.error(
+                                "Received unexpected content type: %s", content_type
+                            )
+                            return None
+                    elif response.status == 401:
+                        _LOGGER.warning("Authorization token expired, will re-authenticate")
+                        # Clear token data so we re-authenticate on next call
+                        self.access_token = None
+                        self.token_expiry = None
+                        raise AuthenticationError("Token expired")
+                    else:
+                        _LOGGER.error(
+                            "Failed to get camera image with status code %s", response.status
+                        )
+                        return None
+        except Exception as err:
+            _LOGGER.error("Error while retrieving camera image: %s", str(err))
+            return None
 
     async def logout(self):
-        """Logout from the API."""
-        logout_url = f"{self.API_URL}/api/Login/Logout"
-        await self._post(logout_url, {})
+        """Log out from the API."""
+        # Clear token data
+        self.access_token = None
+        self.token_expiry = None
+        self.headers = {}
+        _LOGGER.debug("Logged out from Sector Alarm API")
+        return True

--- a/custom_components/phonewatch/config_flow.py
+++ b/custom_components/phonewatch/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
@@ -27,7 +28,25 @@ from homeassistant.helpers.selector import (
 )
 
 from .client import AuthenticationError, SectorAlarmAPI
-from .const import CONF_CODE_FORMAT, CONF_PANEL_ID, DOMAIN
+from .const import (
+    CONF_CODE_FORMAT,
+    CONF_FETCH_CAMERAS,
+    CONF_FETCH_DOORS_WINDOWS,
+    CONF_FETCH_HUMIDITY,
+    CONF_FETCH_LEAKAGE,
+    CONF_FETCH_SMARTPLUGS,
+    CONF_FETCH_SMOKE,
+    CONF_FETCH_TEMPERATURES,
+    CONF_PANEL_ID,
+    DEFAULT_FETCH_CAMERAS,
+    DEFAULT_FETCH_DOORS_WINDOWS,
+    DEFAULT_FETCH_HUMIDITY,
+    DEFAULT_FETCH_LEAKAGE,
+    DEFAULT_FETCH_SMARTPLUGS,
+    DEFAULT_FETCH_SMOKE,
+    DEFAULT_FETCH_TEMPERATURES,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +67,25 @@ DATA_SCHEMA_OPTIONS = vol.Schema(
         vol.Optional(CONF_CODE_FORMAT, default=6): NumberSelector(
             NumberSelectorConfig(min=0, max=6, step=1, mode=NumberSelectorMode.BOX)
         ),
+        vol.Optional(
+            CONF_FETCH_TEMPERATURES, default=DEFAULT_FETCH_TEMPERATURES
+        ): BooleanSelector(),
+        vol.Optional(
+            CONF_FETCH_HUMIDITY, default=DEFAULT_FETCH_HUMIDITY
+        ): BooleanSelector(),
+        vol.Optional(
+            CONF_FETCH_LEAKAGE, default=DEFAULT_FETCH_LEAKAGE
+        ): BooleanSelector(),
+        vol.Optional(CONF_FETCH_SMOKE, default=DEFAULT_FETCH_SMOKE): BooleanSelector(),
+        vol.Optional(
+            CONF_FETCH_DOORS_WINDOWS, default=DEFAULT_FETCH_DOORS_WINDOWS
+        ): BooleanSelector(),
+        vol.Optional(
+            CONF_FETCH_CAMERAS, default=DEFAULT_FETCH_CAMERAS
+        ): BooleanSelector(),
+        vol.Optional(
+            CONF_FETCH_SMARTPLUGS, default=DEFAULT_FETCH_SMARTPLUGS
+        ): BooleanSelector(),
     }
 )
 
@@ -130,6 +168,13 @@ class SectorAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
                         },
                         options={
                             CONF_CODE_FORMAT: self.code_format,
+                            CONF_FETCH_TEMPERATURES: DEFAULT_FETCH_TEMPERATURES,
+                            CONF_FETCH_HUMIDITY: DEFAULT_FETCH_HUMIDITY,
+                            CONF_FETCH_LEAKAGE: DEFAULT_FETCH_LEAKAGE,
+                            CONF_FETCH_SMOKE: DEFAULT_FETCH_SMOKE,
+                            CONF_FETCH_DOORS_WINDOWS: DEFAULT_FETCH_DOORS_WINDOWS,
+                            CONF_FETCH_CAMERAS: DEFAULT_FETCH_CAMERAS,
+                            CONF_FETCH_SMARTPLUGS: DEFAULT_FETCH_SMARTPLUGS,
                         },
                     )
                 else:
@@ -165,6 +210,13 @@ class SectorAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
                 },
                 options={
                     CONF_CODE_FORMAT: self.code_format,
+                    CONF_FETCH_TEMPERATURES: DEFAULT_FETCH_TEMPERATURES,
+                    CONF_FETCH_HUMIDITY: DEFAULT_FETCH_HUMIDITY,
+                    CONF_FETCH_LEAKAGE: DEFAULT_FETCH_LEAKAGE,
+                    CONF_FETCH_SMOKE: DEFAULT_FETCH_SMOKE,
+                    CONF_FETCH_DOORS_WINDOWS: DEFAULT_FETCH_DOORS_WINDOWS,
+                    CONF_FETCH_CAMERAS: DEFAULT_FETCH_CAMERAS,
+                    CONF_FETCH_SMARTPLUGS: DEFAULT_FETCH_SMARTPLUGS,
                 },
             )
 

--- a/custom_components/phonewatch/const.py
+++ b/custom_components/phonewatch/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Sector Alarm integration."""
+"""Constants for the Phone Watch Alarm integration."""
 
 from homeassistant.const import Platform
 
@@ -31,3 +31,32 @@ CATEGORY_MODEL_MAPPING = {
 
 CONF_PANEL_ID = "panel_id"
 CONF_CODE_FORMAT = "code_format"
+
+# Data type configuration options
+CONF_FETCH_TEMPERATURES = "fetch_temperatures"
+CONF_FETCH_HUMIDITY = "fetch_humidity"
+CONF_FETCH_LEAKAGE = "fetch_leakage_detectors"
+CONF_FETCH_SMOKE = "fetch_smoke_detectors"
+CONF_FETCH_DOORS_WINDOWS = "fetch_doors_windows"
+CONF_FETCH_CAMERAS = "fetch_cameras"
+CONF_FETCH_SMARTPLUGS = "fetch_smartplugs"
+
+# Map configuration options to data endpoint keys
+CONFIG_TO_ENDPOINT_MAP = {
+    CONF_FETCH_TEMPERATURES: "Temperatures",
+    CONF_FETCH_HUMIDITY: "Humidity",
+    CONF_FETCH_LEAKAGE: "Leakage Detectors",
+    CONF_FETCH_SMOKE: "Smoke Detectors",
+    CONF_FETCH_DOORS_WINDOWS: "Doors and Windows",
+    CONF_FETCH_CAMERAS: "Cameras", 
+    CONF_FETCH_SMARTPLUGS: "Smartplug Status",
+}
+
+# Default values for selective fetching
+DEFAULT_FETCH_TEMPERATURES = False  # Off by default as noted in readme
+DEFAULT_FETCH_HUMIDITY = True
+DEFAULT_FETCH_LEAKAGE = True
+DEFAULT_FETCH_SMOKE = True
+DEFAULT_FETCH_DOORS_WINDOWS = True
+DEFAULT_FETCH_CAMERAS = True
+DEFAULT_FETCH_SMARTPLUGS = True

--- a/custom_components/phonewatch/entity.py
+++ b/custom_components/phonewatch/entity.py
@@ -1,4 +1,4 @@
-"""Base entity for Sector Alarm integration."""
+"""Base entity for Phone Watch Alarm integration."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SectorAlarmBaseEntity(CoordinatorEntity[SectorDataUpdateCoordinator]):
-    """Representation of a Sector Alarm base entity."""
+    """Representation of a Phone Watch Alarm base entity."""
 
     _attr_has_entity_name = True
 
@@ -43,7 +43,7 @@ class SectorAlarmBaseEntity(CoordinatorEntity[SectorDataUpdateCoordinator]):
         return DeviceInfo(
             identifiers={(DOMAIN, self._serial_no)},
             name=self.device_name,
-            manufacturer="Sector Alarm",
+            manufacturer="Phone Watch",
             model=self.device_model,
             serial_number=self._serial_no,
         )

--- a/custom_components/phonewatch/strings.json
+++ b/custom_components/phonewatch/strings.json
@@ -8,7 +8,7 @@
     },
     "select_panel": {
       "title": "Select alarm panel",
-      "description": "Choose which panel you’d like to connect."
+      "description": "Choose which panel you'd like to connect."
     },
     "reauth_confirm": {
       "title": "Reauthenticate Phone Watch",
@@ -30,7 +30,14 @@
       "title": "Configure options",
       "description": "Optional settings for your panel.",
       "data": {
-        "code_format": "Code length"
+        "code_format": "Code length",
+        "fetch_temperatures": "Fetch temperature sensors (may be slow)",
+        "fetch_humidity": "Fetch humidity sensors",
+        "fetch_leakage_detectors": "Fetch leakage detectors",
+        "fetch_smoke_detectors": "Fetch smoke detectors",
+        "fetch_doors_windows": "Fetch doors and windows",
+        "fetch_cameras": "Fetch cameras",
+        "fetch_smartplugs": "Fetch smart plugs"
       }
     }
   }

--- a/custom_components/phonewatch/translations/en.json
+++ b/custom_components/phonewatch/translations/en.json
@@ -8,7 +8,7 @@
     },
     "select_panel": {
       "title": "Select alarm panel",
-      "description": "Choose which panel you’d like to connect."
+      "description": "Choose which panel you'd like to connect."
     },
     "reauth_confirm": {
       "title": "Reauthenticate Phone Watch",
@@ -30,7 +30,14 @@
       "title": "Configure options",
       "description": "Optional settings for your panel.",
       "data": {
-        "code_format": "Code length"
+        "code_format": "Code length",
+        "fetch_temperatures": "Fetch temperature sensors (may be slow)",
+        "fetch_humidity": "Fetch humidity sensors",
+        "fetch_leakage_detectors": "Fetch leakage detectors",
+        "fetch_smoke_detectors": "Fetch smoke detectors",
+        "fetch_doors_windows": "Fetch doors and windows",
+        "fetch_cameras": "Fetch cameras",
+        "fetch_smartplugs": "Fetch smart plugs"
       }
     }
   }

--- a/custom_components/phonewatch/translations/se.json
+++ b/custom_components/phonewatch/translations/se.json
@@ -42,7 +42,14 @@
         "title": "Konfigurera alternativ",
         "description": "Valfria inställningar för din panel.",
         "data": {
-          "code_format": "Kodlängd"
+          "code_format": "Kodlängd",
+          "fetch_temperatures": "Hämta temperatursensorer (kan vara långsam)",
+          "fetch_humidity": "Hämta fuktighetssensorer",
+          "fetch_leakage_detectors": "Hämta läckagesensorer",
+          "fetch_smoke_detectors": "Hämta rökdetektorer",
+          "fetch_doors_windows": "Hämta dörrar och fönster",
+          "fetch_cameras": "Hämta kameror",
+          "fetch_smartplugs": "Hämta smarta uttag"
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sector Alarm",
+  "name": "Phone Watch Alarm",
   "render_readme": true,
   "homeassistant": "2024.11.0"
 }

--- a/readme.md
+++ b/readme.md
@@ -36,17 +36,31 @@ On alarm installation which are not wired make sure you take the binary sensor "
 
 The entity for alarm panel will only update it's state on alarms which are online
 
+## Features
+
+- Improved token handling with automatic refresh (reduces API calls)
+- Exponential backoff retry for improved reliability
+- Selective data fetching for better performance
+- Comprehensive error handling
+
 ## Configuration Options
 
 Set once:
 
 - Username: Your e-mail address linked to Sector Alarm account
 - Password: Password used for app or Sector website
-- Enable Temp sensors (Not recommended and turned off by default due to long api response time)
 
 Options that you can change at any time:
 
 - Code Format: Number of digits in code
+- Selective Data Fetching: Enable/disable fetching of specific sensor types to optimize performance
+  - Temperature Sensors (off by default due to slow API response)
+  - Humidity Sensors
+  - Leakage Detectors
+  - Smoke Detectors
+  - Doors and Windows
+  - Cameras
+  - Smart Plugs
 
 ## Installation
 
@@ -58,9 +72,9 @@ Use [HACS](https://hacs.xyz/) to install
 
 Below config-folder create a new folder called`custom_components` if not already exist.
 
-Below new `custom_components` folder create a new folder called `sector`
+Below new `custom_components` folder create a new folder called `phonewatch`
 
-Upload the files/folders in `custom_components/sector` directory to the newly created folder.
+Upload the files/folders in `custom_components/phonewatch` directory to the newly created folder.
 
 Restart before proceeding
 


### PR DESCRIPTION
Updated the integration to rename 'Sector Alarm' to 'Phone Watch Alarm' across all files, including constants, strings, and documentation. Added selective data fetching options and improved token handling with automatic refresh and exponential backoff retry for better reliability.